### PR TITLE
Gpus issue gh48

### DIFF
--- a/benchmarker/modules/do_tensorflow.py
+++ b/benchmarker/modules/do_tensorflow.py
@@ -21,8 +21,10 @@ class Benchmark(INeuralNet):
         os.environ["KERAS_BACKEND"] = "tensorflow"
 
     def get_strategy(self):
-        tf_gpus = tf.config.list_physical_devices("GPU")
-        assert self.params["nb_gpus"] == len(tf_gpus)
+        gpu_count_same = self.params["nb_gpus"] == len(
+            tf.config.list_physical_devices("GPU")
+        )
+        assert gpu_count_same, "Tensorflow not compiled with GPU support"
         try:
             tpu = tf.distribute.cluster_resolver.TPUClusterResolver()  # TPU detection
         except ValueError:

--- a/benchmarker/modules/do_tensorflow.py
+++ b/benchmarker/modules/do_tensorflow.py
@@ -44,10 +44,7 @@ class Benchmark(INeuralNet):
         elif len(gpus) > 1:
             strategy = tf.distribute.MirroredStrategy(gpus)
         elif self.params["nb_gpus"] == 1:
-            if tf.test.gpu_device_name():
-                strategy = tf.distribute.get_strategy()
-            else:
-                raise RuntimeError("No GPU found")
+            strategy = tf.distribute.get_strategy()
         else:  # Make sure we run on CPU
             strategy = tf.distribute.get_strategy()
 

--- a/benchmarker/modules/do_tensorflow.py
+++ b/benchmarker/modules/do_tensorflow.py
@@ -16,9 +16,6 @@ class Benchmark(INeuralNet):
     def __init__(self, params, remaining_args=None):
         gpus = params["gpus"]
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpus)) if gpus else "-1"
-        if params["nb_gpus"] > 1:
-            print("multiple gpus with TF not supported yet")
-            return
         super().__init__(params, remaining_args)
         self.params["channels_first"] = False
         os.environ["KERAS_BACKEND"] = "tensorflow"

--- a/benchmarker/modules/do_tensorflow.py
+++ b/benchmarker/modules/do_tensorflow.py
@@ -14,7 +14,8 @@ class Benchmark(INeuralNet):
     """docstring for ClassName"""
 
     def __init__(self, params, remaining_args=None):
-        os.environ["CUDA_VISIBLE_DEVICES"] = str(params["nb_gpus"] - 1)
+        gpus = params["gpus"]
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, gpus)) if gpus else "-1"
         if params["nb_gpus"] > 1:
             print("multiple gpus with TF not supported yet")
             return


### PR DESCRIPTION
I hope the logic is taken care of properly.

If you have `tensorflow-cpu` installed and run with `--gpus=0,1` it will say:
```
  File "/home/vatai/code/benchmarker/benchmarker/modules/do_tensorflow.py", line 27, in get_strategy
    assert gpu_count_same, "Tensorflow not compiled with GPU support"
```

Also fixed the `CUDA_VISIBLE_DEVICES` stuff a little. So apperently you should set it to the ids of the GPUs (basically the same as the value of our `--gpus`) or -1 if you want no GPUs.