### PR TITLE
Fix (mini fix) pytorch output

### DIFF
--- a/benchmarker/modules/do_pytorch.py
+++ b/benchmarker/modules/do_pytorch.py
@@ -35,7 +35,7 @@ class Benchmark(INeuralNet):
             log_interval = 10
             if batch_idx % log_interval == 0:
                 print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
-                    epoch, batch_idx * len(data), len(self.x_train),
+                    epoch, batch_idx, len(self.x_train),
                     100. * batch_idx / len(self.x_train), loss.mean().item()))
         if device.type == "cuda":
             torch.cuda.synchronize()


### PR DESCRIPTION
`batch_idx` is multiplied by `len(data)` (which results in the number
of samples processed). This doesn't match the next value after '/', is
`len(self.x_train)` which is the total number of batches (and not
total number of samples).

This closes #66