### PR TITLE
Add missing --nb_epoch=1 to some tests

### DIFF
--- a/test/tensorflow/test_vgg19.py
+++ b/test/tensorflow/test_vgg19.py
@@ -14,6 +14,7 @@ class TensorflowTests(unittest.TestCase):
             "--framework=tensorflow",
             "--problem_size=4",
             "--batch_size=2",
+            "--nb_epoch=1",
         ]
 
     def test_vgg19(self):

--- a/test/tensorflow/test_xception.py
+++ b/test/tensorflow/test_xception.py
@@ -14,6 +14,7 @@ class XceptionTests(unittest.TestCase):
             "--framework=tensorflow",
             "--problem_size=4",
             "--batch_size=2",
+            "--nb_epoch=1",
         ]
 
     def test_xception(self):


### PR DESCRIPTION
Tensorflow VGG19 and Xception tests didn't set `--nb_epoch=1` which speeds up tests