### PR TITLE
Fapp

### DIFF
--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -52,11 +52,14 @@ def main():
         if args.flops:
             result["problem"]["gflop_measured"] = get_nvprof_counters(command)
     else:
-        if result["platform"]["cpu"]["brand"] is not None:
-            result["device"] = result["platform"]["cpu"]["brand"]
-        else:
+        if (
+            "brand" not in result["platform"]["cpu"]
+            or result["platform"]["cpu"]["brand"] is None
+        ):
             # TODO: add arch when it becomes available thougg sys query
             result["device"] = "unknown CPU"
+        else:
+            result["device"] = result["platform"]["cpu"]["brand"]
         if args.flops:
             result["problem"]["gflop_measured"] = get_counters(command)
         if args.fapp_power:

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -5,6 +5,7 @@ import json
 import os
 import sys
 
+from benchmarker import fapp
 from benchmarker.nvprof import get_nvprof_counters
 from benchmarker.perf import get_counters
 # from .benchmarker import run
@@ -29,6 +30,7 @@ def main():
     parser.add_argument("--path_out", type=str, default="./logs")
     parser.add_argument("--problem")
     parser.add_argument("--flops", action="store_true")
+    parser.add_argument("--fapp_power", action="store_true")
     args, unknown_args = parser.parse_known_args()
 
     command = ["python3", "-m", "benchmarker.benchmarker"]
@@ -54,6 +56,9 @@ def main():
             result["device"] = result["platform"]["cpu"]["brand"]
             if args.flops:
                 result["problem"]["gflop_measured"] = get_counters(command)
+            if args.fapp_power:
+                total, details = fapp.get_power_total_and_detail(command)
+                result["problem"]["power"] = {"total": total, "details": details}
         else:
             # TODO: add arch when it becomes available thougg sys query
             result["device"] = "unknown CPU"

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -1,17 +1,19 @@
 """CLI entry point module"""
 
-import sys
-import json
 import argparse
+import json
 import os
-from .util import sysinfo
+import sys
 
+from benchmarker.nvprof import get_nvprof_counters
+from benchmarker.perf import get_counters
 # from .benchmarker import run
 from benchmarker.util import abstractprocess
 from benchmarker.util.cute_device import get_cute_device_str
+
+from .util import sysinfo
 from .util.io import save_json
-from benchmarker.perf import get_counters
-from benchmarker.nvprof import get_nvprof_counters
+
 
 def filter_json_from_output(lines):
     parts = lines.split("benchmarkmagic#!%")
@@ -23,8 +25,8 @@ def filter_json_from_output(lines):
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Benchmark me up, Scotty!')
-    parser.add_argument('--path_out', type=str, default="./logs")
+    parser = argparse.ArgumentParser(description="Benchmark me up, Scotty!")
+    parser.add_argument("--path_out", type=str, default="./logs")
     parser.add_argument("--problem")
     parser.add_argument("--flops", action="store_true")
     args, unknown_args = parser.parse_known_args()
@@ -38,7 +40,7 @@ def main():
     if returncode != 0:
         process_err = proc_output["err"]
         sys.exit(process_err)
-        
+
     process_out = proc_output["out"]
     result = filter_json_from_output(process_out)
     # TODO: don't parse path_out in the innder loop
@@ -61,6 +63,7 @@ def main():
     result["path_out"] = os.path.join(result["path_out"], cute_device)
     save_json(result)
     # TODO: don't measure power when measureing flops
+
 
 if __name__ == "__main__":
     main()

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -54,14 +54,14 @@ def main():
     else:
         if result["platform"]["cpu"]["brand"] is not None:
             result["device"] = result["platform"]["cpu"]["brand"]
-            if args.flops:
-                result["problem"]["gflop_measured"] = get_counters(command)
-            if args.fapp_power:
-                total, details = fapp.get_power_total_and_detail(command)
-                result["problem"]["power"] = {"total": total, "details": details}
         else:
             # TODO: add arch when it becomes available thougg sys query
             result["device"] = "unknown CPU"
+        if args.flops:
+            result["problem"]["gflop_measured"] = get_counters(command)
+        if args.fapp_power:
+            total, details = fapp.get_power_total_and_detail(command)
+            result["problem"]["power"] = {"total": total, "details": details}
     result["path_out"] = args.path_out
     cute_device = get_cute_device_str(result["device"]).replace(" ", "_")
     result["path_out"] = os.path.join(result["path_out"], result["problem"]["name"])

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -27,14 +27,12 @@ def filter_json_from_output(lines):
 
 def main():
     parser = argparse.ArgumentParser(description="Benchmark me up, Scotty!")
-    parser.add_argument("--path_out", type=str, default="./logs")
-    parser.add_argument("--problem")
     parser.add_argument("--flops", action="store_true")
     parser.add_argument("--fapp_power", action="store_true")
     args, unknown_args = parser.parse_known_args()
 
     command = ["python3", "-m", "benchmarker.benchmarker"]
-    command += sys.argv[1:]
+    command += unknown_args
     proc = abstractprocess.Process("local", command=command)
     proc_output = proc.get_output()
     returncode = proc_output["returncode"]
@@ -62,10 +60,9 @@ def main():
             result["device"] = result["platform"]["cpu"]["brand"]
         if args.flops:
             result["problem"]["gflop_measured"] = get_counters(command)
-        if args.fapp_power:
+        elif args.fapp_power:
             total, details = fapp.get_power_total_and_detail(command)
             result["problem"]["power"] = {"total": total, "details": details}
-    result["path_out"] = args.path_out
     cute_device = get_cute_device_str(result["device"]).replace(" ", "_")
     result["path_out"] = os.path.join(result["path_out"], result["problem"]["name"])
     result["path_out"] = os.path.join(result["path_out"], cute_device)

--- a/benchmarker/benchmarker.py
+++ b/benchmarker/benchmarker.py
@@ -7,7 +7,6 @@ This is where all magic is happening
 import argparse
 import ast
 import importlib
-# import logging
 import os
 import pkgutil
 import sys
@@ -27,18 +26,12 @@ def get_modules():
 def parse_basic_args(argv):
     parser = argparse.ArgumentParser(description="Benchmark me up, Scotty!")
     parser.add_argument("--framework")
-    ### What to do? (probably better here!)
     parser.add_argument("--problem")
-    ### What to do? (probably better here!)
     parser.add_argument("--path_out", type=str, default="./logs")
     parser.add_argument("--gpus", default="")
     parser.add_argument("--problem_size", default=None)
     parser.add_argument("--batch_size", default=None)
     parser.add_argument("--power_sampling_ms", type=int, default=100)
-    ### REMOVE!
-    parser.add_argument("--flops", action="store_true")
-    ### REMOVE!
-    parser.add_argument("--fapp_power", action="store_true")
     # parser.add_argument('--misc')
     return parser.parse_known_args(argv)
 

--- a/benchmarker/benchmarker.py
+++ b/benchmarker/benchmarker.py
@@ -27,13 +27,18 @@ def get_modules():
 def parse_basic_args(argv):
     parser = argparse.ArgumentParser(description="Benchmark me up, Scotty!")
     parser.add_argument("--framework")
+    ### What to do? (probably better here!)
     parser.add_argument("--problem")
+    ### What to do? (probably better here!)
     parser.add_argument("--path_out", type=str, default="./logs")
     parser.add_argument("--gpus", default="")
     parser.add_argument("--problem_size", default=None)
     parser.add_argument("--batch_size", default=None)
     parser.add_argument("--power_sampling_ms", type=int, default=100)
+    ### REMOVE!
     parser.add_argument("--flops", action="store_true")
+    ### REMOVE!
+    parser.add_argument("--fapp_power", action="store_true")
     # parser.add_argument('--misc')
     return parser.parse_known_args(argv)
 

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -4,7 +4,7 @@ from benchmarker.fapp_power import get_power, get_total_power
 from benchmarker.util import abstractprocess
 
 
-def run_fapp_profiler(fapp_dir, command):
+def run_fapp_profiler(fapp_dir, rep, command):
     # fapp -C -d ./prof_${APP}_rep${REP} -Hevent=pa${REP} ./${APP}
     fapp_measure_cmd = ["fapp", "-C", "-d"]
     fapp_measure_cmd += [fapp_dir, f"-Hevent=pa{rep}"]
@@ -28,7 +28,7 @@ def get_power_total_and_detail(command):
         for rep in [1, 8]:
             with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
                 csv_file = f"{csv_dir}/pa{rep}.csv"
-                run_fapp_profiler(fapp_dir, command)
+                run_fapp_profiler(fapp_dir, rep, command)
                 gen_fapp_csv(fapp_dir, csv_file)
         power_details = get_power(csv_dir)
         power_total = get_total_power(power_details)

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from benchmarker.fapp_power import get_power, get_total_power
@@ -23,7 +22,6 @@ def gen_fapp_csv(fapp_dir, csv_file):
 
 
 def get_power_total_and_detail(command):
-    csv_dir = Path("csvs")
     with TemporaryDirectory() as csv_dir:
         for rep in [1, 8]:
             with TemporaryDirectory(suffix=str(rep)) as fapp_dir:

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -1,23 +1,32 @@
 import re
 import subprocess
+from tempfile import TemporaryDirectory
 
 from benchmarker.util import abstractprocess
+
+
+def run_fapp_profiler(fapp_dir, command):
+    # fapp -C -d ./prof_${APP}_rep${REP} -Hevent=pa${REP} ./${APP}
+    fapp_measure_cmd = ["fapp", "-C", "-d"]
+    fapp_measure_cmd += [fapp_dir, "-Hevent=pa{rep}"]
+    proc = abstractprocess.Process("local", command=fapp_measure_cmd + command)
+
+
+def gen_fapp_csv(fap_dir, csv_file):
+    # fapp -A -tcsv -o ${APP}_reps/pa$REP.csv -d ./prof_${APP}_rep${REP} -Icpupa
+    fapp_gen_csv_cmd = ["fapp", "-A", "-tcsv"]
+    fapp_gen_csv_cmd += ["-o", csv_file] + ["-d", fapp_dir, "-Icpupa"]
+    proc = abstractprocess.Process("local", command=fapp_gen_csv_cmd)
 
 
 def get_counters(command):
     flop_measured = 0
     for counter in perf_counters_multipliers:
         for rep in [1, 8]:
-            fapp_output = "./prof"
-            csv_output = "./csvs/"
-            # fmt: off
-            # fapp -C -d ./prof_${APP}_rep${REP} -Hevent=pa${REP} ./${APP}
-            fapp_measure_cmd = ["fapp", "-C", "-d", f"./prof_rep{rep} -Hevent=pa{rep}"]
-            # fapp -A -tcsv -o ${APP}_reps/pa$REP.csv -d ./prof_${APP}_rep${REP} -Icpupa
-            fapp_gen_csv_cmd = ["fapp", "-A", "-tcsv", "-o", "reps/pa{rep}.csv", "-d", "./prof_rep{rep}", "-Icpupa",]
-            # fmt: on
-            proc = abstractprocess.Process("local", command=fapp_measure_cmd + command)
-
+            fapp_dir = f"./prof{rep}"
+            csv_file = f"./csvs/pa{rep}.csv"
+            run_fapp_profiler(fapp_dir, command)
+            gen_fapp_csv(fap_dir, csv_file)
             # process_err = proc.get_output()["err"]
             # print(process_err)
         # delete tmp files

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -19,7 +19,7 @@ def gen_fapp_csv(fapp_dir, csv_file):
     abstractprocess.Process("local", command=fapp_gen_csv_cmd)
 
 
-def get_counters(command):
+def get_power_total_and_detail(command):
     csv_dir = Path("csvs")
     for rep in [1, 8]:
         with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
@@ -28,8 +28,8 @@ def get_counters(command):
             gen_fapp_csv(fapp_dir, csv_file)
         # delete fapp_dir
 
-    power = get_power(csv_dir)
-    total_power = get_total_power(power)
+    power_details = get_power(csv_dir)
+    power_total = get_total_power(power_details)
     csv_dir.rmdir()
 
-    return gflop_measured
+    return power_total, power_details

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -10,7 +10,8 @@ def run_fapp_profiler(fapp_dir, command):
     fapp_measure_cmd += [fapp_dir, "-Hevent=pa{rep}"]
     cmd = fapp_measure_cmd + command
     print(cmd)
-    abstractprocess.Process("local", command=cmd)
+    proc = abstractprocess.Process("local", command=cmd)
+    print(proc.get_output())
 
 
 def gen_fapp_csv(fapp_dir, csv_file):
@@ -18,7 +19,8 @@ def gen_fapp_csv(fapp_dir, csv_file):
     fapp_gen_csv_cmd = ["fapp", "-A", "-tcsv"]
     fapp_gen_csv_cmd += ["-o", csv_file] + ["-d", fapp_dir, "-Icpupa"]
     print(fapp_gen_csv_cmd)
-    abstractprocess.Process("local", command=fapp_gen_csv_cmd)
+    proc = abstractprocess.Process("local", command=fapp_gen_csv_cmd)
+    print(proc.get_output())
 
 
 def get_power_total_and_detail(command):

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -9,18 +9,22 @@ def run_fapp_profiler(fapp_dir, command):
     # fapp -C -d ./prof_${APP}_rep${REP} -Hevent=pa${REP} ./${APP}
     fapp_measure_cmd = ["fapp", "-C", "-d"]
     fapp_measure_cmd += [fapp_dir, "-Hevent=pa{rep}"]
-    abstractprocess.Process("local", command=fapp_measure_cmd + command)
+    cmd = fapp_measure_cmd + command
+    print(cmd)
+    abstractprocess.Process("local", command=cmd)
 
 
 def gen_fapp_csv(fapp_dir, csv_file):
     # fapp -A -tcsv -o $APP_reps/pa$REP.csv -d ./prof_$APP_rep$REP -Icpupa
     fapp_gen_csv_cmd = ["fapp", "-A", "-tcsv"]
     fapp_gen_csv_cmd += ["-o", csv_file] + ["-d", fapp_dir, "-Icpupa"]
+    print(fapp_gen_csv_cmd)
     abstractprocess.Process("local", command=fapp_gen_csv_cmd)
 
 
 def get_power_total_and_detail(command):
     csv_dir = Path("csvs")
+    csv_dir.mkdir()
     for rep in [1, 8]:
         with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
             csv_file = csv_dir.joinpath(f"pa{rep}.csv")

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -9,18 +9,14 @@ def run_fapp_profiler(fapp_dir, rep, command):
     fapp_measure_cmd = ["fapp", "-C", "-d"]
     fapp_measure_cmd += [fapp_dir, f"-Hevent=pa{rep}"]
     cmd = fapp_measure_cmd + command
-    print(cmd)
-    proc = abstractprocess.Process("local", command=cmd)
-    print(proc.get_output())
+    abstractprocess.Process("local", command=cmd)
 
 
 def gen_fapp_csv(fapp_dir, csv_file):
     # fapp -A -tcsv -o $APP_reps/pa$REP.csv -d ./prof_$APP_rep$REP -Icpupa
     fapp_gen_csv_cmd = ["fapp", "-A", "-tcsv"]
     fapp_gen_csv_cmd += ["-o", csv_file] + ["-d", fapp_dir, "-Icpupa"]
-    print(fapp_gen_csv_cmd)
-    proc = abstractprocess.Process("local", command=fapp_gen_csv_cmd)
-    print(proc.get_output())
+    abstractprocess.Process("local", command=fapp_gen_csv_cmd)
 
 
 def get_power_total_and_detail(command):

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -1,0 +1,21 @@
+import re
+import subprocess
+
+from benchmarker.util import abstractprocess
+
+perf_counters_multipliers = {"r5302c7": 1, "r5308c7": 4, "r5320c7": 8}
+
+
+def get_counters(command):
+    flop_measured = 0
+    for counter in perf_counters_multipliers:
+        perf_command = ["perf", "stat", "-e", counter]
+        proc = abstractprocess.Process("local", command=perf_command + command)
+        process_err = proc.get_output()["err"]
+        # print(process_err)
+        match_exp = re.compile("[\d|\,]+\s+" + counter).search(process_err)
+        match_list = match_exp.group().split()
+        cntr_value = int(match_list[0].replace(",", ""))
+        flop_measured += perf_counters_multipliers[counter] * cntr_value
+    gflop_measured = flop_measured / 10 ** 9
+    return gflop_measured

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from benchmarker.fapp_power import get_power, get_total_power
 from benchmarker.util import abstractprocess
-from fapp_power import get_power, get_total_power
 
 
 def run_fapp_profiler(fapp_dir, command):

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -24,16 +24,14 @@ def gen_fapp_csv(fapp_dir, csv_file):
 
 def get_power_total_and_detail(command):
     csv_dir = Path("csvs")
-    csv_dir.mkdir()
-    for rep in [1, 8]:
-        with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
-            csv_file = str(csv_dir.joinpath(f"pa{rep}.csv"))
-            run_fapp_profiler(fapp_dir, command)
-            gen_fapp_csv(fapp_dir, csv_file)
-        # delete fapp_dir
+    with TemporaryDirectory() as csv_dir:
+        for rep in [1, 8]:
+            with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
+                csv_file = f"{csv_dir}/pa{rep}.csv"
+                run_fapp_profiler(fapp_dir, command)
+                gen_fapp_csv(fapp_dir, csv_file)
 
-    power_details = get_power(csv_dir)
-    power_total = get_total_power(power_details)
-    csv_dir.rmdir()
+        power_details = get_power(csv_dir)
+        power_total = get_total_power(power_details)
 
     return power_total, power_details

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -7,7 +7,7 @@ from benchmarker.util import abstractprocess
 def run_fapp_profiler(fapp_dir, command):
     # fapp -C -d ./prof_${APP}_rep${REP} -Hevent=pa${REP} ./${APP}
     fapp_measure_cmd = ["fapp", "-C", "-d"]
-    fapp_measure_cmd += [fapp_dir, "-Hevent=pa{rep}"]
+    fapp_measure_cmd += [fapp_dir, f"-Hevent=pa{rep}"]
     cmd = fapp_measure_cmd + command
     print(cmd)
     proc = abstractprocess.Process("local", command=cmd)
@@ -30,7 +30,6 @@ def get_power_total_and_detail(command):
                 csv_file = f"{csv_dir}/pa{rep}.csv"
                 run_fapp_profiler(fapp_dir, command)
                 gen_fapp_csv(fapp_dir, csv_file)
-
         power_details = get_power(csv_dir)
         power_total = get_total_power(power_details)
 

--- a/benchmarker/fapp.py
+++ b/benchmarker/fapp.py
@@ -27,7 +27,7 @@ def get_power_total_and_detail(command):
     csv_dir.mkdir()
     for rep in [1, 8]:
         with TemporaryDirectory(suffix=str(rep)) as fapp_dir:
-            csv_file = csv_dir.joinpath(f"pa{rep}.csv")
+            csv_file = str(csv_dir.joinpath(f"pa{rep}.csv"))
             run_fapp_profiler(fapp_dir, command)
             gen_fapp_csv(fapp_dir, csv_file)
         # delete fapp_dir

--- a/benchmarker/fapp_power.py
+++ b/benchmarker/fapp_power.py
@@ -1,4 +1,5 @@
 import csv
+from pathlib import Path
 
 import pandas as pd
 
@@ -63,6 +64,7 @@ def get_mem_power(mem_counter, freq, cntvct):
 
 
 def get_cmg_power(csv_dir, cmg_id, region="all"):
+    csv_dir = Path(csv_dir)
     pa1 = split_csv(csv_dir.joinpath("pa1.csv"))
     pa8 = split_csv(csv_dir.joinpath("pa8.csv"))
 

--- a/benchmarker/fapp_power.py
+++ b/benchmarker/fapp_power.py
@@ -1,0 +1,106 @@
+import csv
+
+import pandas as pd
+
+
+def split_csv(pafile):
+    with open(pafile) as csvfile:
+        csvs = []
+        row_len = 0
+        reader = csv.reader(csvfile)
+        for row in reader:
+            if len(row) != row_len:
+                csvs.append([])
+                row_len = len(row)
+            csvs[-1].append(row)
+    return csvs
+
+
+def get_df(csv):
+    return pd.DataFrame(csv[1:], columns=csv[0])
+
+
+def get_freq(pa8):
+    freq_df = get_df(pa8[0])
+    name = "Timer clock frequency"
+    freq = freq_df[freq_df.Name == name].Value.array[0]
+    return float(freq)
+
+
+def get_cores(pa8, cmg_id):
+    cgm_df = get_df(pa8[2])
+    cores = cgm_df[cgm_df.CMG == str(cmg_id)].Thread.array
+    return cores
+
+
+def get_tag(pafile, tag, region_name, cores):
+    df = get_df(pafile[4])
+    region_idcs = df["Region_name"] == region_name
+    if cores.shape != (0,):
+        cores_idcs = df.Thread.isin(cores)
+    else:
+        cores_idcs = df.Thread != "-"
+    retdf = df[cores_idcs & region_idcs][tag]
+    return retdf.astype("int64")
+
+
+def get_core_power(core_counter, freq, cntvct):
+    core_power = core_counter * freq * 8
+    core_power /= cntvct.astype("float") * (10 ** 9)
+    return core_power
+
+
+def get_L2_power(L2_counter, freq, cntvct):
+    L2_power = L2_counter.mean() * freq * 32
+    L2_power /= cntvct.mean() * (10 ** 9)
+    return L2_power
+
+
+def get_mem_power(mem_counter, freq, cntvct):
+    mem_power = mem_counter.mean() * freq * 256
+    mem_power /= cntvct.mean() * (10 ** 9)
+    return mem_power
+
+
+def get_cmg_power(csv_dir, cmg_id, region="all"):
+    pa1 = split_csv(csv_dir.joinpath("pa1.csv"))
+    pa8 = split_csv(csv_dir.joinpath("pa8.csv"))
+
+    freq = get_freq(pa8)
+    cores = get_cores(pa8, cmg_id=cmg_id)
+    if cores.shape == (0,):
+        return None
+    cntvct = get_tag(pa1, "CNTVCT", region, cores)
+    core_counter = get_tag(pa8, "0x01e0", region, cores)
+    L2_counter = get_tag(pa8, "0x03e0", region, cores)
+    mem_counter = get_tag(pa8, "0x03e8", region, cores)
+
+    core_power = get_core_power(core_counter, freq, cntvct)
+    L2_power = get_L2_power(L2_counter, freq, cntvct)
+    mem_power = get_mem_power(mem_counter, freq, cntvct)
+
+    # fmt: off
+    return dict(core=list(core_power.array),
+                L2=float(L2_power),
+                mem=float(mem_power))
+    # fmt: on
+
+
+def get_power(csv_dir):
+
+    # csv_dir = pathlib.Path(csv_dir) # used to postfix _reps here
+    nb_cmgs = 4
+    power = [{} for _ in range(nb_cmgs)]
+    for cmg_id in range(nb_cmgs):
+        power[cmg_id] = get_cmg_power(csv_dir, cmg_id)
+    return power
+
+
+def get_total_power(power):
+    total = 0.0
+    for cmg_power in power:
+        if cmg_power is not None:
+            total += sum(cmg_power["core"])
+            total += cmg_power["L2"]
+            total += cmg_power["mem"]
+    return total


### PR DESCRIPTION
Done! I think it is:
![Borat](https://i.imgur.com/lqKlotB.png)

So, the switch to enable it is `--fapp_power`.

I've added two files: `benchmarker/fapp.py` and `benchmarker/fapp_power.py`. The former file implements the logic of calling `fapp` (with the considerations it might be expanded in the future to measure other things than power). The latter file implements the details of extracting the values from the `.csv` files generated by `fapp`.

The output is something like this:
```
    "problem": {
        "flop_estimated": 4194304.0,
        "gflop_estimated": 0.004194304,
        "name": "gemm",
        "power": {
            "details": [
                null,
                null,
                {
                    "L2": 1.2766175701150815,
                    "core": [
                        1.5079641451442003
                    ],
                    "mem": 1.1799673449212413
                },
                null
            ],
            "total": 3.964549060180523
        },
```