### PR TITLE
Fix freeze

### DIFF
--- a/benchmarker/benchmarker.py
+++ b/benchmarker/benchmarker.py
@@ -82,8 +82,8 @@ def run(argv):
     params["power"]["avg_watt_total"] = 0
     mod = importlib.import_module("benchmarker.modules.do_" + params["framework"])
     benchmark = getattr(mod, "Benchmark")(params, unknown_args)
-    benchmark.run()
-    # save_json(params)
+    # TODO: make this optional
+    benchmark.measure_power_and_run()
     print("benchmarkmagic#!%")
     print_json(params)
 

--- a/benchmarker/modules/do_chainer.py
+++ b/benchmarker/modules/do_chainer.py
@@ -90,7 +90,7 @@ class Benchmark(INeuralNet):
         trainer.extend(extensions.PrintReport(['epoch', 'main/loss', 'main/accuracy', "elapsed_time"]))
         trainer.run()
 
-    def run_internal(self):
+    def run(self):
         # TODO set a config option to use ChainerX or other backend
         use_chainer_x = False
         params = self.params

--- a/benchmarker/modules/do_cublas.py
+++ b/benchmarker/modules/do_cublas.py
@@ -1,7 +1,6 @@
 import os
 from .i_gemm import IGEMM
 from benchmarker.util.abstractprocess import Process
-from .power_mon import power_monitor_GPU
 
 
 class Benchmark(IGEMM):
@@ -22,12 +21,8 @@ class Benchmark(IGEMM):
                    * map(str, self.params['problem']['size']),
                    str(self.params["nb_epoch"])]
         # TODO(Alex): think of how to reuse this across all problems
-        power_monitor_gpu = power_monitor_GPU(self.params)
-        power_monitor_gpu.start()
         process = Process(command=command)
         result = process.get_output()
         std_out = result["out"]
         elapsed_time = float(std_out.strip())
         self.params["time_total"] = elapsed_time
-        power_monitor_gpu.stop()
-        self.post_process()

--- a/benchmarker/modules/do_mxnet.py
+++ b/benchmarker/modules/do_mxnet.py
@@ -15,7 +15,7 @@ class Benchmark(INeuralNet):
         # TODO: confirm tensor ordering in mxnet
         # self.params["channels_first"] = True
 
-    def run_internal(self):
+    def run(self):
         params = self.params
         x_train, y_train = self.load_data()
 

--- a/benchmarker/modules/do_opencv.py
+++ b/benchmarker/modules/do_opencv.py
@@ -14,7 +14,7 @@ class Benchmark(INeuralNet):
         if self.params["batch_size"] != 1:
             raise RuntimeError("opencv only supports batch size of 1")
 
-    def run_internal(self):
+    def run(self):
         params = self.params
         x_train, y_train = self.load_data()
         x_train = x_train.reshape((x_train.shape[0] * x_train.shape[1],) + x_train.shape[2:])

--- a/benchmarker/modules/do_pytorch.py
+++ b/benchmarker/modules/do_pytorch.py
@@ -87,7 +87,7 @@ class Benchmark(INeuralNet):
         if self.params["nb_gpus"] > 0:
             torch.cuda.synchronize()
 
-    def run_internal(self):
+    def run(self):
         model = self.net
         if len(self.params["gpus"]) > 1:
             model = nn.DataParallel(model)

--- a/benchmarker/modules/do_tensorflow.py
+++ b/benchmarker/modules/do_tensorflow.py
@@ -76,7 +76,7 @@ class Benchmark(INeuralNet):
         super().set_random_seed(seed)
         tf.random.set_seed(seed)
 
-    def run_internal(self):
+    def run(self):
         model = self.net
         nb_epoch = self.params["nb_epoch"]
         if self.params["mode"] == "training":

--- a/benchmarker/modules/do_tflite.py
+++ b/benchmarker/modules/do_tflite.py
@@ -82,7 +82,7 @@ class Benchmark(INeuralNet):
             experimental_delegates=[delegate],
         )
 
-    def run_internal(self):
+    def run(self):
         assert self.params["mode"] == "inference", "Only inference supported ATM"
 
         # preheat

--- a/benchmarker/modules/do_torch.py
+++ b/benchmarker/modules/do_torch.py
@@ -6,7 +6,6 @@ from timeit import default_timer as timer
 import torch
 import numpy as np
 from .i_gemm import IGEMM
-from .power_mon import power_monitor_GPU
 
 
 class Benchmark(IGEMM):
@@ -34,8 +33,6 @@ class Benchmark(IGEMM):
                 c = c.to(device)
                 c = a @ b  # this is preheat
                 torch.cuda.synchronize()
-        power_monitor_gpu = power_monitor_GPU(self.params)
-        power_monitor_gpu.start()
         time_start = timer()
         for _ in range(self.params["nb_epoch"]):
             c = a @ b  # + c
@@ -43,5 +40,3 @@ class Benchmark(IGEMM):
             torch.cuda.synchronize()
         time_end = timer()
         self.params["time_total"] = (time_end - time_start)
-        power_monitor_gpu.stop()
-        self.post_process()

--- a/benchmarker/modules/i_benchmark.py
+++ b/benchmarker/modules/i_benchmark.py
@@ -1,0 +1,21 @@
+from .power_mon import power_monitor_GPU, power_monitor_RAPL
+
+
+class IBenchmark:
+    def measure_power_and_run(self):
+        if self.params["nb_gpus"] > 0:
+            power_monitor_gpu = power_monitor_GPU(self.params)
+            power_monitor_gpu.start()
+        power_monitor_cpu = power_monitor_RAPL(self.params)
+        power_monitor_cpu.start()
+        try:
+            results = self.run()
+        except Exception as e:
+            power_monitor_gpu.stop()
+            raise e
+        if self.params["nb_gpus"] > 0:
+            power_monitor_gpu.stop()
+            power_monitor_gpu.post_process()
+        power_monitor_cpu.stop()
+        self.post_process()
+        return results

--- a/benchmarker/modules/i_gemm.py
+++ b/benchmarker/modules/i_gemm.py
@@ -2,9 +2,10 @@
 import argparse
 import os
 from .ops import detalize_ops_results
+from .i_benchmark import IBenchmark
 
 
-class IGEMM():
+class IGEMM(IBenchmark):
     """Interface for all deep learning modules"""
 
     def __init__(self, params, remaining_args=None):

--- a/benchmarker/modules/i_neural_net.py
+++ b/benchmarker/modules/i_neural_net.py
@@ -6,11 +6,11 @@ import random
 
 import numpy
 
-from .power_mon import power_monitor_GPU, power_monitor_RAPL
 from .ops import detalize_ops_results
+from .i_benchmark import IBenchmark
 
 
-class INeuralNet:
+class INeuralNet(IBenchmark):
     """Interface for all deep learning modules"""
 
     def __init__(self, params, extra_args=None):
@@ -102,16 +102,3 @@ class INeuralNet:
             results["samples_per_joule"] = (
                 results["problem"]["cnt_samples"] * results["nb_epoch"] / self.params["power"]["joules_total"]
             )
-
-    def run(self):
-        if self.params["nb_gpus"] > 0:
-            power_monitor_gpu = power_monitor_GPU(self.params)
-            power_monitor_gpu.start()
-        power_monitor_cpu = power_monitor_RAPL(self.params)
-        power_monitor_cpu.start()
-        results = self.run_internal()
-        if self.params["nb_gpus"] > 0:
-            power_monitor_gpu.stop()
-        power_monitor_cpu.stop()
-        self.post_process()
-        return results

--- a/benchmarker/modules/i_neural_net.py
+++ b/benchmarker/modules/i_neural_net.py
@@ -87,16 +87,8 @@ class INeuralNet:
         numpy.random.seed(seed)
         random.seed(seed)
 
-    def run(self):
-        if self.params["nb_gpus"] > 0:
-            power_monitor_gpu = power_monitor_GPU(self.params)
-            power_monitor_gpu.start()
-        power_monitor_cpu = power_monitor_RAPL(self.params)
-        power_monitor_cpu.start()
-        results = self.run_internal()
-        if self.params["nb_gpus"] > 0:
-            power_monitor_gpu.stop()
-        power_monitor_cpu.stop()
+    def post_process(self):
+        results = self.params
         results["time_batch"] = (
             results["time_epoch"] / results["problem"]["cnt_batches_per_epoch"]
         )
@@ -111,4 +103,15 @@ class INeuralNet:
                 results["problem"]["cnt_samples"] * results["nb_epoch"] / self.params["power"]["joules_total"]
             )
 
-            return results
+    def run(self):
+        if self.params["nb_gpus"] > 0:
+            power_monitor_gpu = power_monitor_GPU(self.params)
+            power_monitor_gpu.start()
+        power_monitor_cpu = power_monitor_RAPL(self.params)
+        power_monitor_cpu.start()
+        results = self.run_internal()
+        if self.params["nb_gpus"] > 0:
+            power_monitor_gpu.stop()
+        power_monitor_cpu.stop()
+        self.post_process()
+        return results

--- a/benchmarker/modules/power_mon.py
+++ b/benchmarker/modules/power_mon.py
@@ -31,6 +31,8 @@ class power_monitor_GPU:
         self.thread_monitor.join()
         self.nvml.nvmlShutdown()
         # a small hack to remove pre-heat time measurement
+
+    def post_process(self):
         cnt_cut_measurements = min(len(self.lst_power_gpu), 100)
         measurements_trimmed = self.lst_power_gpu[:cnt_cut_measurements]
         self.params["power"]["avg_watt_GPU"] = np.mean(measurements_trimmed)


### PR DESCRIPTION
terminates monitoring threads on exception in the main one (e.g. CUDA out of memory)

some refactoring to make this (and monitoring itself) reusable across modules