### PR TITLE
estimate ops for bert_custom

### DIFF
--- a/benchmarker/modules/problems/bert/pytorch.py
+++ b/benchmarker/modules/problems/bert/pytorch.py
@@ -1,22 +1,12 @@
-from benchmarker.modules.problems.attention.pytorch import \
-    estimate_attention_gflop_per_sample
 from benchmarker.modules.problems.helpers_torch_bert import get_kernel_by_name
-
-
-def estimate_gflop_per_sample(len_seq, embed_dim, lin_dim, nb_layers):
-    attention_gflop = estimate_attention_gflop_per_sample(len_seq, embed_dim)
-    mid_linear_gflop = 2 * embed_dim * lin_dim * len_seq / (10 ** 9)
-    top_linear_gflop = 2 * embed_dim * lin_dim * len_seq / (10 ** 9)
-    layer_gflop = attention_gflop + mid_linear_gflop + top_linear_gflop
-    # TODO: add layer norm
-    # TODO: get inner linear size from HF config object
-    return nb_layers * layer_gflop
+from benchmarker.modules.problems.bert_custom import estimate_gflop_per_sample
 
 
 def get_kernel(params):
     cnt_samples = params["problem"]["size"][0]
     len_seq = params["problem"]["size"][1]
     assert len_seq <= 512, "BERT sequence length must be <= 512 because of saved positional embeddings"
+    # TODO: get inner linear size from HF config object
     gflop_per_sample = estimate_gflop_per_sample(
         len_seq=len_seq,
         embed_dim=768,

--- a/benchmarker/modules/problems/bert_custom/__init__.py
+++ b/benchmarker/modules/problems/bert_custom/__init__.py
@@ -1,0 +1,11 @@
+from benchmarker.modules.problems.attention.pytorch import \
+    estimate_attention_gflop_per_sample
+
+
+def estimate_gflop_per_sample(len_seq, embed_dim, lin_dim, nb_layers):
+    attention_gflop = estimate_attention_gflop_per_sample(len_seq, embed_dim)
+    mid_linear_gflop = 2 * embed_dim * lin_dim * len_seq / (10 ** 9)
+    top_linear_gflop = 2 * embed_dim * lin_dim * len_seq / (10 ** 9)
+    layer_gflop = attention_gflop + mid_linear_gflop + top_linear_gflop
+    # TODO: add layer norm
+    return nb_layers * layer_gflop


### PR DESCRIPTION
```
python3 -m benchmarker --framework=pytorch --problem=bert_custom --problem_size=64,128,64 --batch_size=2  --mode=inference --flops
```

```
        "gflop_estimated": 536.870912,
        "gflop_measured": 543.484227377,
```