### PR TITLE
Hide pandas importing

### DIFF
--- a/benchmarker/fapp_power.py
+++ b/benchmarker/fapp_power.py
@@ -1,8 +1,6 @@
 import csv
 from pathlib import Path
 
-import pandas as pd
-
 
 def split_csv(pafile):
     with open(pafile) as csvfile:
@@ -18,6 +16,8 @@ def split_csv(pafile):
 
 
 def get_df(csv):
+    import pandas as pd
+
     return pd.DataFrame(csv[1:], columns=csv[0])
 
 


### PR DESCRIPTION
Hide pandas importing by putting the import inside the function definition which uses it. So, if `fapp` option is not used, pandas is not imported... and since sometimes it is problematic to build pandas... this can be a lifesaver :grin: 