### PR TITLE
Epyc mi100

### DIFF
--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -22,7 +22,7 @@ def fixup_for_amd_gpus(result):
         for i in range(nb_gpus):
             device_name = torch.cuda.get_device_name(i)
             assert device_name == "Device 738c"
-            gpu = {"brand": "AMD", "name": "Mi100"}
+            gpu = {"brand": "AMD Mi100"}
             gpus.append(gpu)
 
         result["platform"]["gpus"] = gpus

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -53,8 +53,14 @@ def main():
     result = benchmarker.benchmarker.run(unknown_args)
 
     # TODO: don't parse path_out in the innder loop
-    print(result)
     result["platform"] = sysinfo.get_sys_info()
+    if len(result["gpus"]) != result["nb_gpus"] and result["framework"] == "pytorch":
+        print(result)
+        import torch.cuda
+
+        nb_gpus = storch.cuda.device_count()
+        print("NB_GPUS", nb_gpus)
+
     result["start_time"] = get_time_str()
     if result["nb_gpus"] > 0:
         precision = result["problem"]["precision"]

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -11,6 +11,23 @@ from .util import sysinfo
 from .util.io import get_time_str, save_json
 
 
+def fixup_for_amd_gpus(result):
+    same_gpu_count = len(result["platform"]["gpus"]) == result["nb_gpus"]
+    using_pytorch = result["framework"] == "pytorch"
+    if using_pytorch and not same_gpu_count:
+        import torch.cuda
+
+        nb_gpus = torch.cuda.device_count()
+        gpus = []
+        for i in range(nb_gpus):
+            device_name = torch.cuda.get_device_name(i)
+            assert device_name == "Device 738c"
+            gpu = {"brand": "AMD", "name": "Mi100"}
+            gpus.append(gpu)
+
+        result["platform"]["gpus"] = gpus
+
+
 def get_args():
     parser = argparse.ArgumentParser(description="Benchmark me up, Scotty!")
     parser.add_argument("--flops", action="store_true", default=False)
@@ -54,23 +71,7 @@ def main():
 
     # TODO: don't parse path_out in the innder loop
     result["platform"] = sysinfo.get_sys_info()
-
-    ## start
-    same_gpu_count = len(result["platform"]["gpus"]) == result["nb_gpus"]
-    using_pytorch = result["framework"] == "pytorch"
-    if using_pytorch and not same_gpu_count:
-        import torch.cuda
-
-        nb_gpus = torch.cuda.device_count()
-        gpus = []
-        for i in range(nb_gpus):
-            gpu = {"brand": "AMD", "name": torch.cuda.get_device_name(i)}
-            gpus.append(gpu)
-
-        print("RESULT GPUS", result["platform"]["gpus"])
-        print("GPUS", gpus)
-        result["platform"]["gpus"] = gpus
-    ## end
+    fixup_for_amd_gpus(result)
 
     result["start_time"] = get_time_str()
     if result["nb_gpus"] > 0:

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -54,7 +54,10 @@ def main():
 
     # TODO: don't parse path_out in the innder loop
     result["platform"] = sysinfo.get_sys_info()
-    if len(result["gpus"]) != result["nb_gpus"] and result["framework"] == "pytorch":
+    if (
+        len(result["platform"]["gpus"]) != result["nb_gpus"]
+        and result["framework"] == "pytorch"
+    ):
         print(result)
         import torch.cuda
 

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -53,6 +53,7 @@ def main():
     result = benchmarker.benchmarker.run(unknown_args)
 
     # TODO: don't parse path_out in the innder loop
+    print(result)
     result["platform"] = sysinfo.get_sys_info()
     result["start_time"] = get_time_str()
     if result["nb_gpus"] > 0:

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -54,15 +54,23 @@ def main():
 
     # TODO: don't parse path_out in the innder loop
     result["platform"] = sysinfo.get_sys_info()
-    if (
-        len(result["platform"]["gpus"]) != result["nb_gpus"]
-        and result["framework"] == "pytorch"
-    ):
-        print(result)
+
+    ## start
+    same_gpu_count = len(result["platform"]["gpus"]) == result["nb_gpus"]
+    using_pytorch = result["framework"] == "pytorch"
+    if using_pytorch and not same_gpu_count:
         import torch.cuda
 
         nb_gpus = torch.cuda.device_count()
-        print("NB_GPUS", nb_gpus)
+        gpus = []
+        for i in range(nb_gpus):
+            gpu = {"brand": "AMD", "name": torch.cuda.get_device_name(i)}
+            gpus.append(gpu)
+
+        print("RESULT GPUS", result["platform"]["gpus"])
+        print("GPUS", gpus)
+        result["platform"]["gpus"] = gpus
+    ## end
 
     result["start_time"] = get_time_str()
     if result["nb_gpus"] > 0:

--- a/benchmarker/__main__.py
+++ b/benchmarker/__main__.py
@@ -61,7 +61,7 @@ def main():
         print(result)
         import torch.cuda
 
-        nb_gpus = storch.cuda.device_count()
+        nb_gpus = torch.cuda.device_count()
         print("NB_GPUS", nb_gpus)
 
     result["start_time"] = get_time_str()

--- a/benchmarker/util/sysinfo.py
+++ b/benchmarker/util/sysinfo.py
@@ -6,7 +6,7 @@ from benchmarker.util import abstractprocess, get_script_dir
 
 
 def get_sys_info():
-    script_path = os.path.join(get_script_dir(), '_sysinfo.py')
+    script_path = os.path.join(get_script_dir(), "_sysinfo.py")
     script_cmd = [sys.executable, script_path]
     proc = abstractprocess.Process("local", command=script_cmd)
     result = proc.get_output()
@@ -21,7 +21,7 @@ def get_sys_info():
 
 def main():
     info = get_sys_info()
-    print(json.dumps(info, sort_keys=True, indent=4, separators=(',', ': ')))
+    print(json.dumps(info, sort_keys=True, indent=4, separators=(",", ": ")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See sample output below. Just adding a the `"brand"` (i.e. device name) and not adding other stuff like memory/cores/clock speed etc, because either I don't know how to do it or `torch.cuda` doesn't support it...

```
docr_user@container_epyc:/workdir$ python3 -m benchmarker --gpus=0 --framework=pytorch --problem=resnet50 --problem_size=32
/usr/local/lib/python3.8/dist-packages/torch/nn/functional.py:718: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered internally at  /pytorch/c10/core/TensorImpl.h:1156.)
  return torch.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)
Train Epoch: 1 [0/1 (0%)]       Loss: 6.887599
Train Epoch: 2 [0/1 (0%)]       Loss: 5.317784
Train Epoch: 3 [0/1 (0%)]       Loss: 4.018268
Train Epoch: 4 [0/1 (0%)]       Loss: 2.858533
Train Epoch: 5 [0/1 (0%)]       Loss: 1.861015
Train Epoch: 6 [0/1 (0%)]       Loss: 1.092951
Train Epoch: 7 [0/1 (0%)]       Loss: 0.597454
Train Epoch: 8 [0/1 (0%)]       Loss: 0.325032
Train Epoch: 9 [0/1 (0%)]       Loss: 0.188242
Train Epoch: 10 [0/1 (0%)]      Loss: 0.117798
{
    "backend": "native",
    "batch_size": 32,
    "batch_size_per_device": 32,
    "channels_first": true,
    "cudnn_benchmark": true,
    "device": "AMD Mi100",
    "framework": "pytorch",
    "framework_full": "PyTorch-1.9.0+rocm4.2",
    "gpus": [
        0
    ],
    "mode": "training",
    "nb_epoch": 10,
    "nb_gpus": 1,
    "path_ext": "training",
    "path_out": "./logs",
    "platform": {
        "cpu": {
            "brand": "AMD EPYC 7452 32-Core Processor",
            "cache": {
                "1": 2097152,
                "2": 33554432,
                "3": 524288
            },
            "clock": 1752.0227968749998,
            "clock_max": 2350.0,
            "clock_min": 1500.0,
            "logical_cores": 64,
            "physical_cores": 64
        },
        "gpus": [
            {
                "brand": "AMD Mi100"
            }
        ],
        "hdds": {
            "/dev/sda": {
                "model": "INTEL SSDSC2KB48",
                "size": 937703088
            },
            "/dev/sdb": {
                "model": "KINGSTON SEDC500",
                "size": 7501476528
            }
        },
        "host": "container_epyc.m.gsic.titech.ac.jp",
        "os": "Linux-4.18.0-305.19.1.el8_4.x86_64-x86_64-with-glibc2.29",
        "ram": {
            "total": 270051356672
        },
        "swap": 4294963200
    },
    "power": {
        "avg_watt_total": 0,
        "joules_total": 0,
        "sampling_ms": 100
    },
    "preheat": false,
    "problem": {
        "cnt_batches_per_epoch": 1,
        "cnt_samples": 32,
        "name": "resnet50",
        "precision": "FP32",
        "size": [
            32,
            3,
            224,
            224
        ]
    },
    "profile_pytorch": false,
    "samples_per_second": 3.2585156763245204,
    "start_time": "21.10.07_02.16.27",
    "tensor_layout": "native",
    "time_batch": 9.820422296109609,
    "time_epoch": 9.820422296109609,
    "time_sample": 0.30688819675342527,
    "time_total": 98.2042229610961
}

```